### PR TITLE
Add a doc for the schools endpoint

### DIFF
--- a/v3/schools.md
+++ b/v3/schools.md
@@ -1,0 +1,20 @@
+# Schools
+
+## Object Definitions
+---
+
+## School
+```
+{ "id": Integer, "name": String }
+```
+
+## Endpoints
+---
+
+## GET /api/v3/schools (authenticated)
+
+### Returns:
+```
+[ School ]
+```
+


### PR DESCRIPTION
## Why?
This API has been added for the user to select a school during the sign-up flow.

## What Changed?
Document `/api/v3/schools`